### PR TITLE
fix: PlantUML workflow - .pumlファイルを正しく検出

### DIFF
--- a/.github/workflows/plantuml-to-wiki.yml
+++ b/.github/workflows/plantuml-to-wiki.yml
@@ -38,7 +38,11 @@ jobs:
       # すべての .puml を再帰レンダリング（各ディレクトリ直下に rendered/ ができる）
       - name: Render all .puml to PNG & SVG
         run: |
-          plantuml -recurse -tpng -tsvg -o rendered .
+          find . -name "*.puml" -type f | while read -r puml_file; do
+            echo "Processing: $puml_file"
+            dir=$(dirname "$puml_file")
+            plantuml -tpng -tsvg -o "$dir/rendered" "$puml_file"
+          done
 
       # Wiki 側の出力ルートをクリアし、rendered/配下の画像だけをまとめてコピー
       - name: Sync rendered images into wiki/uml


### PR DESCRIPTION
## 問題
PlantUMLワークフローが「No diagram found」エラーで失敗

## 原因
`plantuml -recurse` コマンドが .puml ファイルを検出できていない

## 修正内容
`find` コマンドで明示的に .puml ファイルを検索して処理するように変更

## テスト
マージ後、workflow_dispatch で手動実行して確認