### PR TITLE
fix: PlantUML画像生成とWiki反映の修正

### DIFF
--- a/.github/workflows/plantuml-to-wiki.yml
+++ b/.github/workflows/plantuml-to-wiki.yml
@@ -41,7 +41,10 @@ jobs:
           find . -name "*.puml" -type f | while read -r puml_file; do
             echo "Processing: $puml_file"
             dir=$(dirname "$puml_file")
-            plantuml -tpng -tsvg -o "$dir/rendered" "$puml_file"
+            mkdir -p "$dir/rendered"
+            plantuml -tpng -tsvg -o rendered "$puml_file"
+            echo "Generated files in $dir/rendered:"
+            ls -la "$dir/rendered/" || echo "No files generated"
           done
 
       # Wiki 側の出力ルートをクリアし、rendered/配下の画像だけをまとめてコピー


### PR DESCRIPTION
## 問題
PlantUMLワークフローは正常実行されたが、画像がWikiに反映されていない

## 修正内容
- rendered ディレクトリの作成を明示的に追加
- 生成されたファイルの確認ログを追加

## テスト
マージ後、手動実行して確認